### PR TITLE
One hand: slidetouch listener only on navbar view

### DIFF
--- a/src/com/android/systemui/navigation/smartbar/SmartBarView.java
+++ b/src/com/android/systemui/navigation/smartbar/SmartBarView.java
@@ -172,14 +172,6 @@ public class SmartBarView extends BaseNavigationBar {
         return super.onTouchEvent(event);
     }
 
-    @Override
-    public boolean onInterceptTouchEvent(MotionEvent event) {
-        if (isOneHandedModeEnabled) {
-            mSlideTouchEvent.handleTouchEvent(event);
-        }
-        return super.onInterceptTouchEvent(event);
-    }
-
     ArrayList<String> getCurrentSequence() {
         return mCurrentSequence;
     }


### PR DESCRIPTION
and not on parent views so to call the one hand mode
the gesture needs to start from an empty space on navbar,
not a button