### PR TITLE
Fling kb cursors: long press left/right to keep moving cursor [1/2]

### DIFF
--- a/src/com/android/systemui/navigation/fling/FlingGestureDetector.java
+++ b/src/com/android/systemui/navigation/fling/FlingGestureDetector.java
@@ -117,6 +117,12 @@ public class FlingGestureDetector {
         void onLongPress(MotionEvent e);
 
         /**
+         * Notified when a long press is finished
+         *
+         */
+        void onFinishedLongPress();
+
+        /**
          * Notified of a fling event when it occurs with the initial on down {@link MotionEvent}
          * and the matching up {@link MotionEvent}. The calculated velocity is supplied along
          * the x and y axis in pixels per second.
@@ -181,6 +187,9 @@ public class FlingGestureDetector {
         }
 
         public void onLongPress(MotionEvent e) {
+        }
+
+        public void onFinishedLongPress() {
         }
 
         public boolean onScroll(MotionEvent e1, MotionEvent e2,
@@ -614,6 +623,7 @@ public class FlingGestureDetector {
                     mHandler.removeMessages(TAP);
                     mHandler.removeMessages(SHOW_PRESS);
                     mHandler.removeMessages(LONG_PRESS);
+                    mListener.onFinishedLongPress();
                     mListener.onFirstScroll();
                 }
                 if (distance > mDoubleTapTouchSlopSquare) {
@@ -669,6 +679,7 @@ public class FlingGestureDetector {
             mDeferConfirmSingleTap = false;
             mHandler.removeMessages(SHOW_PRESS);
             mHandler.removeMessages(LONG_PRESS);
+            mListener.onFinishedLongPress();
             break;
 
         case MotionEvent.ACTION_CANCEL:

--- a/src/com/android/systemui/navigation/fling/FlingGestureHandler.java
+++ b/src/com/android/systemui/navigation/fling/FlingGestureHandler.java
@@ -80,6 +80,8 @@ public class FlingGestureHandler implements OnGestureListener, SmartObservable {
         public void onScrollPreloadRecents();
 
         public void onCancelPreloadRecents();
+
+        public void cancelLongPress();
     }
 
     private static Set<Uri> sUris = new HashSet<Uri>();
@@ -232,6 +234,7 @@ public class FlingGestureHandler implements OnGestureListener, SmartObservable {
     @Override
     public boolean onCancel() {
         mReceiver.onCancelPreloadRecents();
+        mReceiver.cancelLongPress();
         return false;
     }
 
@@ -243,6 +246,11 @@ public class FlingGestureHandler implements OnGestureListener, SmartObservable {
         } else {
             mReceiver.onLongLeftPress();
         }
+    }
+
+    @Override
+    public void onFinishedLongPress() {
+        mReceiver.cancelLongPress();
     }
 
     @Override


### PR DESCRIPTION
- the 2nd move will be triggered after a bigger delay to avoid unwanted
cursor move actions after the first move
- single tap right and single tap left actions will go to home screen
as fallback when the feature is enabled and kb is showing

Change-Id: I07e470e33b653972e2cf77514049456fcd368879