### PR TITLE
DUI: fix button custom image icon not being loaded on encrypted device

### DIFF
--- a/src/com/android/systemui/navigation/BaseNavigationBar.java
+++ b/src/com/android/systemui/navigation/BaseNavigationBar.java
@@ -158,6 +158,8 @@ public abstract class BaseNavigationBar extends LinearLayout implements Navigato
             notifyScreenOn(true);
         } else if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
             notifyScreenOn(false);
+        } else if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            notifyBootCompleted();
         } else {
             onReceive(intent);
         }
@@ -185,11 +187,13 @@ public abstract class BaseNavigationBar extends LinearLayout implements Navigato
         filter.addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGING);
         filter.addAction(Intent.ACTION_SCREEN_ON);
         filter.addAction(Intent.ACTION_SCREEN_OFF);
+        filter.addAction(Intent.ACTION_BOOT_COMPLETED);
         context.registerReceiver(mReceiver, filter);
     }
 
-    // require implementation. Surely they have something to clean up
+    // require implementation
     protected abstract void onDispose();
+    protected abstract void notifyBootCompleted();
 
     // any implementation specific handling can be handled here
     protected void onInflateFromUser() {}

--- a/src/com/android/systemui/navigation/fling/FlingView.java
+++ b/src/com/android/systemui/navigation/fling/FlingView.java
@@ -425,6 +425,11 @@ public class FlingView extends BaseNavigationBar {
     }*/
 
     @Override
+    protected void notifyBootCompleted() {
+        mLogoController.updateLogo(FlingView.this, getFlingLogo());
+    }
+
+    @Override
     public void setMediaPlaying(boolean playing) {
         PulseController mPulse = getPulseController();
         if (mPulse != null) {

--- a/src/com/android/systemui/navigation/smartbar/SmartBarView.java
+++ b/src/com/android/systemui/navigation/smartbar/SmartBarView.java
@@ -668,6 +668,11 @@ public class SmartBarView extends BaseNavigationBar {
     }
 
     @Override
+    protected void notifyBootCompleted() {
+        updateCurrentIcons();
+    }
+
+    @Override
     public void reorient() {
         mEditor.prepareToReorient();
         super.reorient();


### PR DESCRIPTION
if the device is fully encrypted, resources in the data partition
can't be loaded till the user fully unlocks the device after boot
inserting the pin, so Fling or SmartBar button icons can't be set
correctly if they are linked to a custom image in that partition.
Navbar code, instead, gets loaded before the unlock steps are done.

This has been noticed on Pixel2xl, shamu and other devices, where for
example the user gets the default DU logo instead of his custom one.

To fix this, we just trigger an icon refresh after the user completes
the unlock process and all files in the data partition are available.

PS: In the future it'd be better to take care of this boot completed event
for all features where we must access personal files on encrypted devices.



Change-Id: Iec5508dba5538ea6530721f40724be1a59db3f22